### PR TITLE
Variable.isValidValue() regex with atomic grouping

### DIFF
--- a/src/main/java/org/pageseeder/furi/Variable.java
+++ b/src/main/java/org/pageseeder/furi/Variable.java
@@ -169,7 +169,7 @@ public class Variable {
    * sequence. This pattern contains non-capturing parentheses to make it easier to get variable
    * values as a group.
    */
-  protected static final Pattern VALID_VALUE = Pattern.compile("(?:[\\w.~-]|(?:%[0-9A-F]{2}))+");
+  protected static final Pattern VALID_VALUE = Pattern.compile("(?>[\\w.~-]|(?>%[0-9A-F]{2}))+");
 
   /**
    * The default value is an empty string.


### PR DESCRIPTION
When a URI is too long, calling `Variable.isValidValue()` will result in a StackOverflowError. 

The reason is the capturing group (`?:`) usage in the `VALID_VALUE` regex. The solution is to update the regex with atomic grouping (`?>`, non-capturing) which is effectively the same regex. 